### PR TITLE
Switch from deprecated Distance.jl to Distances.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ kNN.jl
 
 Basic k-nearest neighbors classification and regression.
 
-For a list of the distance metrics that can be used in k-NN classification, see [Distance.jl](https://github.com/lindahua/Distance.jl)
+For a list of the distance metrics that can be used in k-NN classification, see [Distances.jl](https://github.com/JuliaStats/Distances.jl)
 
 For a list of the smoothing kernels that can be used in kernel regression, see [SmoothingKernel.jl](https://github.com/johnmyleswhite/SmoothingKernels.jl)
 
@@ -13,7 +13,7 @@ For a list of the smoothing kernels that can be used in kernel regression, see [
     using DataArrays
     using DataFrames
     using RDatasets
-    using Distance
+    using Distances
 
     iris = data("datasets", "iris")
     X = array(iris[:, 1:4])'
@@ -38,7 +38,7 @@ For a list of the smoothing kernels that can be used in kernel regression, see [
     using DataArrays
     using DataFrames
     using RDatasets
-    using Distance
+    using Distances
 
     iris = data("datasets", "iris")
     X = array(iris[:, 1:4])'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-Distance
+Distances
 NearestNeighbors
 SmoothingKernels
 StatsBase

--- a/src/kNN.jl
+++ b/src/kNN.jl
@@ -1,11 +1,11 @@
 using StatsBase
-using Distance
+using Distances
 
 module kNN
     export knn, kernelregression
 
     using StatsBase
-    using Distance
+    using Distances
     using NearestNeighbors
 	using SmoothingKernels
 

--- a/test/classifier.jl
+++ b/test/classifier.jl
@@ -4,7 +4,7 @@ module TestClassifier
 	using DataArrays
 	using DataFrames
     using RDatasets
-    using Distance
+    using Distances
     using StatsBase
 
     iris = data("datasets", "iris")


### PR DESCRIPTION
Distance.jl is deprecated now so it makes sense to switch to Distances.jl. (This is my first pull request to an open source project, so I hope I'm following the proper protocol here.)
