### PR TITLE
Fixed deprecation warning about Union(args...) in regress.jl.

### DIFF
--- a/src/regress.jl
+++ b/src/regress.jl
@@ -1,4 +1,4 @@
-immutable KernelRegression{R <: Union(Vector, Matrix), T <: Real}
+immutable KernelRegression{R <: Union{Vector, Matrix}, T <: Real}
     x::R
     y::Vector{T}
     k::Function


### PR DESCRIPTION
Hi John,

Small change to just remove some of the warnings when the package is loaded.

Regards,
Andrew.